### PR TITLE
Add MANIFEST.in 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include README.md
+
+recursive-include genpy_stubgen *.py


### PR DESCRIPTION
`MANIFEST.in` is required for a package to include non Python scripts (e.g. README, LICENSE).