### PR TITLE
Fix _compat.lru_cache to be compatible with py2

### DIFF
--- a/genpy_stubgen/_compat.py
+++ b/genpy_stubgen/_compat.py
@@ -12,20 +12,24 @@ try:
     from functools import lru_cache  # type: ignore
 except ImportError:
     # Provide a simple cache for Python2
-    def lru_cache(func):
-        # type: (Callable[..., TResult]) -> Callable[..., TResult]
-        cache = {}  # type: Dict[Any, Any]
+    def lru_cache():
+        # type: (...) -> Callable[..., TResult]
+        def _lru_cache(func):
+            # type: (Callable[..., TResult]) -> Callable[..., TResult]
+            cache = {}  # type: Dict[Any, Any]
 
-        @functools.wraps(func)
-        def wrapper(*args):
-            # type: (Any) -> TResult
-            key = tuple(args)
-            if key not in cache:
-                ret = func(*args)
-                cache[key] = ret
-            else:
-                ret = cache[key]
+            @functools.wraps(func)
+            def wrapper(*args):
+                # type: (Any) -> TResult
+                key = tuple(args)
+                if key not in cache:
+                    ret = func(*args)
+                    cache[key] = ret
+                else:
+                    ret = cache[key]
 
-            return ret
+                return ret
 
-        return wrapper
+            return wrapper
+
+        return _lru_cache


### PR DESCRIPTION
In Python 3, we can call `lru_cache` in both ways:
```py
@lru_cache
def func():
   ...
```
```py
@lru_cache()
def func():
   ...
```

In this code base, we use the latter one to avoid this conversion logic in Python3, which causes unexpected behavior in some cases.
https://github.com/python/cpython/blob/1b1f9852bda85c01ef124858f293e9c13e04ffce/Lib/functools.py#L508-L513

So I updated the py2-compatible version of `lru_cache` to accept this style.