### PR TITLE
Refactor cli module

### DIFF
--- a/genpyi/cli.py
+++ b/genpyi/cli.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     ]
 
 
-def run_message_stubgen(
+def run_message(
     package,  # type: str
     package_files,  # type: List[str]
     outdir,  # type: Optional[str]
@@ -40,7 +40,7 @@ def run_message_stubgen(
         )
 
 
-def run_service_stubgen(
+def run_service(
     package,  # type: str
     package_files,  # type: List[str]
     outdir,  # type: Optional[str]
@@ -66,7 +66,7 @@ def run_service_stubgen(
         )
 
 
-def run_module_stubgen(
+def run_module(
     package_dir,  # type: str
     outdir,  # type: str
     module_finder,  # type: str
@@ -90,7 +90,7 @@ def _start_module(args):
     if out_dir is None:
         out_dir = package_dir
 
-    run_module_stubgen(package_dir, out_dir, args.module_finder)
+    run_module(package_dir, out_dir, args.module_finder)
 
 
 def _setup_module_options(parser):
@@ -175,11 +175,11 @@ $ {0} module custom_msgs/msg/""".format(
     subparser = parser.add_subparsers()
     _setup_msg_srv_options(
         subparser.add_parser("msg", help="Generate stub files from .msg files"),
-        run_message_stubgen,
+        run_message,
     )
     _setup_msg_srv_options(
         subparser.add_parser("srv", help="Generate stub files from .srv files"),
-        run_service_stubgen,
+        run_service,
     )
     _setup_module_options(
         subparser.add_parser(

--- a/tests/integration_tests/test_messages.py
+++ b/tests/integration_tests/test_messages.py
@@ -1,7 +1,7 @@
 import os
 from typing import Dict, List
 
-from genpyi.cli import run_message_stubgen
+from genpyi import cli
 
 from .utils import assert_output_equals, message_path, temporary_directory
 
@@ -20,7 +20,7 @@ def test_std_msgs(expected_dir, std_msgs_path):
     expected_dir = os.path.join(expected_dir, package, "msg")
 
     with temporary_directory() as td:
-        run_message_stubgen(package, package_files, td, search_paths)
+        cli.run_message(package, package_files, td, search_paths)
 
         assert_output_equals(expected_dir, td, "_Duration.pyi")
         assert_output_equals(expected_dir, td, "_Header.pyi")
@@ -42,7 +42,7 @@ def test_sensor_msgs(expected_dir, std_msgs_path, sensor_msgs_path):
     expected_dir = os.path.join(expected_dir, package, "msg")
 
     with temporary_directory() as td:
-        run_message_stubgen(package, package_files, td, search_paths)
+        cli.run_message(package, package_files, td, search_paths)
 
         assert_output_equals(expected_dir, td, "_JoyFeedback.pyi")
         assert_output_equals(expected_dir, td, "_PointCloud2.pyi")

--- a/tests/integration_tests/test_modules.py
+++ b/tests/integration_tests/test_modules.py
@@ -1,6 +1,6 @@
 import os
 
-from genpyi.cli import run_module_stubgen
+from genpyi import cli
 
 from .utils import assert_output_equals, message_path, service_path, temporary_directory
 
@@ -13,12 +13,12 @@ def test_std_msgs_msg(expected_dir, std_msgs_path, std_msgs_py_path):
     expected_dir = os.path.join(expected_dir, package, "msg")
 
     with temporary_directory() as td:
-        run_module_stubgen(package_dir, td, "genmsg")
+        cli.run_module(package_dir, td, "genmsg")
 
         assert_output_equals(expected_dir, td, "__init__.pyi")
 
     with temporary_directory() as td:
-        run_module_stubgen(package_py_dir, td, "py")
+        cli.run_module(package_py_dir, td, "py")
 
         assert_output_equals(expected_dir, td, "__init__.pyi")
 
@@ -33,11 +33,11 @@ def test_sensor_msgs_srv(
     expected_dir = os.path.join(expected_dir, package, "srv")
 
     with temporary_directory() as td:
-        run_module_stubgen(package_dir, td, "genmsg")
+        cli.run_module(package_dir, td, "genmsg")
 
         assert_output_equals(expected_dir, td, "__init__.pyi")
 
     with temporary_directory() as td:
-        run_module_stubgen(package_py_dir, td, "py")
+        cli.run_module(package_py_dir, td, "py")
 
         assert_output_equals(expected_dir, td, "__init__.pyi")

--- a/tests/integration_tests/test_services.py
+++ b/tests/integration_tests/test_services.py
@@ -1,7 +1,7 @@
 import os
 from typing import Dict, List
 
-from genpyi.cli import run_service_stubgen
+from genpyi import cli
 
 from .utils import assert_output_equals, message_path, service_path, temporary_directory
 
@@ -19,7 +19,7 @@ def test_sensor_msgs(expected_dir, std_msgs_path, sensor_msgs_path):
     expected_dir = os.path.join(expected_dir, package, "srv")
 
     with temporary_directory() as td:
-        run_service_stubgen(package, package_files, td, search_paths)
+        cli.run_service(package, package_files, td, search_paths)
 
         assert_output_equals(expected_dir, td, "_SetCameraInfo.pyi")
 
@@ -41,6 +41,6 @@ def test_nav_msgs(
     expected_dir = os.path.join(expected_dir, package, "srv")
 
     with temporary_directory() as td:
-        run_service_stubgen(package, package_files, td, search_paths)
+        cli.run_service(package, package_files, td, search_paths)
 
         assert_output_equals(expected_dir, td, "_SetMap.pyi")


### PR DESCRIPTION
I removed `stubgen` from function names, which was named after the previous package name `genpy_stubgen`.