### PR TITLE
Mark universal=1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 .mypy_cache/
 .tox/
 __pycache__/
+build/
 dist/
 pip-wheel-metadata/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
As this package is compatible with both Python 2 and Python 3, I added `universal=1` flag to generate `py2.py3` artifacts in `bdist_wheel`.