### PR TITLE
Generate type aliases for request_class and response_class

### DIFF
--- a/genmypy/converter.py
+++ b/genmypy/converter.py
@@ -6,6 +6,7 @@ from genpy.generator import compute_pkg_type
 from ._compat import lru_cache
 from ._typing import TYPE_CHECKING
 from .stub_element import (
+    AliasElement,
     ClassElement,
     ClassMethodElement,
     CommentElement,
@@ -191,13 +192,13 @@ def convert_message_class(first_party_package, spec, imports):
     return msgclass
 
 
-def convert_service_class(spec):
-    # type: (SrvSpec) -> ClassElement
+def convert_service_class(spec, request_class, response_class):
+    # type: (SrvSpec, ClassElement, ClassElement) -> ClassElement
     srvclass = ClassElement(spec.short_name, "object")
     srvclass.add(FieldElement("_type", "str"))
     srvclass.add(FieldElement("_md5sum", "str"))
-    srvclass.add(FieldElement("_request_class", "str"))
-    srvclass.add(FieldElement("_response_class", "str"))
+    srvclass.add(AliasElement("_request_class", request_class.name))
+    srvclass.add(AliasElement("_response_class", response_class.name))
 
     return srvclass
 

--- a/genmypy/generator.py
+++ b/genmypy/generator.py
@@ -53,7 +53,9 @@ def generate_service_stub(package, spec):
     module.add_element(EmptyLinesElement())
     module.add_element(message_classes[1])  # response class
     module.add_element(EmptyLinesElement())
-    module.add_element(convert_service_class(spec))  # service class
+    module.add_element(
+        convert_service_class(spec, message_classes[0], message_classes[1])
+    )  # service class
 
     for line in module.generate():
         yield line

--- a/genmypy/stub_element.py
+++ b/genmypy/stub_element.py
@@ -152,6 +152,17 @@ class FieldElement(StatementElementBase):
         yield _format("{}: {}".format(self.name, self.type), indent)
 
 
+class AliasElement(StatementElementBase):
+    def __init__(self, name, alias):
+        # type: (str, str) -> None
+        self.name = name
+        self.alias = alias
+
+    def generate(self, indent):
+        # type: (int) -> Iterator[str]
+        yield _format("{} = {}".format(self.name, self.alias), indent)
+
+
 class FunctionElement(StatementElementBase):
     def __init__(self, name, return_type, params=None):
         # type: (str, str, Optional[Sequence[ParameterElement]]) -> None

--- a/tests/integration_tests/expected/nav_msgs/srv/_SetMap.pyi
+++ b/tests/integration_tests/expected/nav_msgs/srv/_SetMap.pyi
@@ -51,5 +51,5 @@ class SetMapResponse(genpy.Message):
 class SetMap(object):
     _type: str
     _md5sum: str
-    _request_class: str
-    _response_class: str
+    _request_class = SetMapRequest
+    _response_class = SetMapResponse

--- a/tests/integration_tests/expected/sensor_msgs/srv/_SetCameraInfo.pyi
+++ b/tests/integration_tests/expected/sensor_msgs/srv/_SetCameraInfo.pyi
@@ -55,5 +55,5 @@ class SetCameraInfoResponse(genpy.Message):
 class SetCameraInfo(object):
     _type: str
     _md5sum: str
-    _request_class: str
-    _response_class: str
+    _request_class = SetCameraInfoRequest
+    _response_class = SetCameraInfoResponse


### PR DESCRIPTION
`_request_class` and `_response_class` should be aliases for request and response classes, respectively.