### PR TITLE
Use bytes for uint8[] field

### DIFF
--- a/genmypy/converter.py
+++ b/genmypy/converter.py
@@ -64,6 +64,11 @@ def _get_genmsg_type(first_party_package, field_type, imports):
         base_field_type, is_array, array_len = genmsg.msgs.parse_type(field_type)
         assert is_array
         # TODO: Handle array_len (use typing.Annotated?)
+
+        if base_field_type == "uint8":
+            # Special case for uint8[]
+            return "bytes"
+
         base_type = _get_genmsg_type(first_party_package, base_field_type, imports)
         return "typing.List[{}]".format(base_type)
 

--- a/tests/integration_tests/expected/sensor_msgs/msg/_Image.pyi
+++ b/tests/integration_tests/expected/sensor_msgs/msg/_Image.pyi
@@ -19,7 +19,7 @@ class Image(genpy.Message):
     encoding: str
     is_bigendian: int
     step: int
-    data: typing.List[int]
+    data: bytes
 
     def __init__(
         self,
@@ -29,7 +29,7 @@ class Image(genpy.Message):
         encoding: str = ...,
         is_bigendian: int = ...,
         step: int = ...,
-        data: typing.List[int] = ...,
+        data: bytes = ...,
         *args: typing.Any,
         **kwds: typing.Any,
     ) -> None: ...

--- a/tests/integration_tests/expected/sensor_msgs/msg/_PointCloud2.pyi
+++ b/tests/integration_tests/expected/sensor_msgs/msg/_PointCloud2.pyi
@@ -21,7 +21,7 @@ class PointCloud2(genpy.Message):
     is_bigendian: bool
     point_step: int
     row_step: int
-    data: typing.List[int]
+    data: bytes
     is_dense: bool
 
     def __init__(
@@ -33,7 +33,7 @@ class PointCloud2(genpy.Message):
         is_bigendian: bool = ...,
         point_step: int = ...,
         row_step: int = ...,
-        data: typing.List[int] = ...,
+        data: bytes = ...,
         is_dense: bool = ...,
         *args: typing.Any,
         **kwds: typing.Any,


### PR DESCRIPTION
Merge #39 first

ROS uses `bytes` for the `uint8[]`, so I added the special-case handling for that.