### PR TITLE
Attempt to solve inconsistent results when using genmypy cmake hooks in catkin workspace

### DIFF
--- a/cmake/genmypy-extras.cmake.em
+++ b/cmake/genmypy-extras.cmake.em
@@ -57,7 +57,7 @@ macro(_generate_module_mypy ARG_PKG ARG_GEN_OUTPUT_DIR ARG_GENERATED_FILES)
 
     if(IS_DIRECTORY ${GEN_OUTPUT_DIR})
       add_custom_command(OUTPUT ${GEN_OUTPUT_FILE}
-        DEPENDS ${GENMYPY_BIN}
+        DEPENDS ${GENMYPY_BIN} ${ARG_PKG}_generate_messages_py
         COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${GENMYPY_BIN} module
           --module-finder py
           --out-dir ${GEN_OUTPUT_DIR}


### PR DESCRIPTION
Hey there, thanks for the rospypi effort in general!

I attempted to use this in my ROS workspaces but had very inconsistent results.
I first thought that it was because the generation of the module files were dependant on the message/services pyi files being generated. While it helped a bit I still couldn't have reproducible builds.
Looking a little bit into it, it looks like the generation of the __init__.pyi files is dependant on already having a proper __init__.py file fully generated for the module. Is that a correct assumption ?

If so by using the changes in this PR I succeeded to have reproducible and more complete __init__.pyi files.
The PR basically introduced a dependency between genpy finishing generating message and module files for the genmypy file generation to kick in.

How I tested this:
- Made a workspace with [the common_msgs repo](https://github.com/ros/common_msgs)
- 5 times:
  - Ran catkin_make_isolated
  - Looked at the number of lines of the generated pyi files

Using current master:
```
$ cat `find -name *.pyi` | wc -l
3747
$ cat `find -name *.pyi` | wc -l
3749
$ cat `find -name *.pyi` | wc -l
3762
$ cat `find -name *.pyi` | wc -l
3751
$ cat `find -name *.pyi` | wc -l
3736

```

Using this PR:

```
$ cat `find -name *.pyi` | wc -l
3765
$ cat `find -name *.pyi` | wc -l
3765
$ cat `find -name *.pyi` | wc -l
3765
$ cat `find -name *.pyi` | wc -l
3765
$ cat `find -name *.pyi` | wc -l
3765
```
