### PR TITLE
Fix incorrect conversion from genmsg primitive `byte` to `int`.

### DIFF
--- a/genmypy/converter.py
+++ b/genmypy/converter.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 _GENMSG_PRIMITIVES = {
-    "byte": "byte",
+    "byte": "int",
     "char": "str",
     "int8": "int",
     "int16": "int",

--- a/tests/integration_tests/expected/std_msgs/msg/_Byte.pyi
+++ b/tests/integration_tests/expected/std_msgs/msg/_Byte.pyi
@@ -1,0 +1,22 @@
+import types
+import typing
+
+import genpy
+
+class Byte(genpy.Message):
+    _md5sum: str
+    _type: str
+    _has_header: bool
+    _full_text: str
+    __slots__: typing.List[str]
+    _slot_types: typing.List[str]
+
+    # Fields
+    data: int
+
+    def __init__(self, data: int = ..., *args: typing.Any, **kwds: typing.Any) -> None: ...
+    def _get_types(self) -> typing.List[str]: ...
+    def serialize(self, buff: typing.BinaryIO) -> None: ...
+    def deserialize(self, str: bytes) -> Byte: ...
+    def serialize_numpy(self, buff: typing.BinaryIO, numpy: types.ModuleType) -> None: ...
+    def deserialize_numpy(self, str: bytes, numpy: types.ModuleType) -> Byte: ...

--- a/tests/integration_tests/test_messages.py
+++ b/tests/integration_tests/test_messages.py
@@ -10,6 +10,7 @@ def test_std_msgs(expected_dir, std_msgs_path):
     # type: (str, str) -> None
     package = "std_msgs"  # type: str
     package_files = [
+        message_path(std_msgs_path, "Byte"),
         message_path(std_msgs_path, "Duration"),
         message_path(std_msgs_path, "Header"),
         message_path(std_msgs_path, "Time"),
@@ -22,6 +23,7 @@ def test_std_msgs(expected_dir, std_msgs_path):
     with temporary_directory() as td:
         cli.run_message(package, package_files, td, search_paths)
 
+        assert_output_equals(expected_dir, td, "_Byte.pyi")
         assert_output_equals(expected_dir, td, "_Duration.pyi")
         assert_output_equals(expected_dir, td, "_Header.pyi")
         assert_output_equals(expected_dir, td, "_Time.pyi")


### PR DESCRIPTION
ROS documentation reports that `byte` type is a deprecated alias of `int8` (https://wiki.ros.org/msg). 

![image](https://github.com/user-attachments/assets/8423c949-40ad-4329-9526-245b7628dc13)

This aligns the conversion of `byte` with the conversion of `int8`, making them both to `int`. 